### PR TITLE
Update push type to omit children key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export declare class CombineProviders {
     private stack;
     constructor();
     private getNode;
-    push<P extends any>(Component: React.ComponentType<P>, props?: P): void;
+    push<P extends any>(Component: React.ComponentType<P>, props?: Omit<P, "children">): void;
     private createProvidersTree;
     render(children: any): any;
     master(): ({ children }: {


### PR DESCRIPTION
Some providers may require a children, but that shouldn't be validated on push since the children will be provided during `render`. A concrete example is material-ui's [ThemeProvider](https://material-ui.com/customization/theming/#theme-provider) that doesn't work without this patch (or passing `children: undefined` to push)